### PR TITLE
댓글 CRUD, 좋아요 기능 구현 및 예외처리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Trillion-NewSpeed-Project
 main에 merge시도 테스트(woojin->main)
 두번째 테스트- woojin에서 readme수정
-해나 github pr테스트
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Trillion-NewSpeed-Project
 main에 merge시도 테스트(woojin->main)
 두번째 테스트- woojin에서 readme수정
+해나 github pr테스트

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -2,7 +2,9 @@ package com.sparta.trillionnewspeedproject.controller;
 
 import com.sparta.trillionnewspeedproject.dto.CommentRequestDto;
 import com.sparta.trillionnewspeedproject.dto.CommentResponseDto;
-import com.sparta.trillionnewspeedproject.util.ResponseMessageUtil;
+import com.sparta.trillionnewspeedproject.dto.ResponseMessageDto;
+import com.sparta.trillionnewspeedproject.exception.ErrorCode;
+import com.sparta.trillionnewspeedproject.exception.GlobalExceptionHandler;
 import com.sparta.trillionnewspeedproject.security.UserDetailsImpl;
 import com.sparta.trillionnewspeedproject.service.CommentService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -18,7 +19,7 @@ import java.util.List;
 @RequestMapping("/api/posts")
 public class CommentController {
 	private final CommentService commentService;
-	private final ResponseMessageUtil responseMessageUtil;
+	private final GlobalExceptionHandler globalExceptionHandler;
 
 	// 선택한 게시글에 대한 모든 댓글 조회
 	@GetMapping("/{postid}/comments")
@@ -34,15 +35,13 @@ public class CommentController {
 
 	// 선택한 댓글 수정
 	@PutMapping("/{postid}/comments/{commentid}")
-	public CommentResponseDto updateComment(@PathVariable Long postid, @PathVariable Long commentid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+	public Object updateComment(@PathVariable Long postid, @PathVariable Long commentid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		CommentResponseDto responseDto = commentService.updateComment(postid, commentid, requestDto, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
-			responseMessageUtil.statusResponse(response, "작성자만 수정할 수 있습니다.");
-			return null;
+			return globalExceptionHandler.badRequestException(ErrorCode.USER_ONLY_ERROR);
 		} else if (response.getStatus() == 404) {
-			responseMessageUtil.statusResponse(response, "주소가 잘못되어 해당 댓글을 찾을 수 없습니다.");
-			return null;
+			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
 		} else {
 			return responseDto;
 		}
@@ -50,29 +49,28 @@ public class CommentController {
 
 	// 선택한 댓글 삭제
 	@DeleteMapping("/{postid}/comments/{commentid}")
-	public void deleteComment(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+	public Object deleteComment(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		commentService.deleteComment(postid, commentid, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
-			responseMessageUtil.statusResponse(response, "작성자만 삭제할 수 있습니다.");
+			return globalExceptionHandler.badRequestException(ErrorCode.USER_ONLY_ERROR);
 		} else if (response.getStatus() == 404) {
-			responseMessageUtil.statusResponse(response, "주소가 잘못되어 해당 댓글을 찾을 수 없습니다.");
+			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
 		} else {
-			responseMessageUtil.statusResponse(response, "해당 댓글의 삭제를 완료하였습니다.");
+			return new ResponseMessageDto("해당 댓글의 삭제를 완료했습니다.", response.getStatus());
 		}
 	}
 
 	// 선택한 댓글 좋아요
 	@PutMapping("/{postid}/comments/{commentid}/likes")
-	public CommentResponseDto commentLike(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+	public Object commentLike(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+		CommentResponseDto responseDto = commentService.commentLike(postid, commentid, userDetails.getUser(), response);
+
 		if (response.getStatus() == 400) {
-			responseMessageUtil.statusResponse(response, "본인이 작성한 댓글에는 좋아요를 누를 수 없습니다.");
-			return null;
+			return globalExceptionHandler.badRequestException(ErrorCode.USER_NOT_ERROR);
 		} else if (response.getStatus() == 404) {
-			responseMessageUtil.statusResponse(response, "주소가 잘못되어 해당 댓글을 찾을 수 없습니다.");
-			return null;
+			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
 		} else {
-			CommentResponseDto responseDto = commentService.commentLike(postid, commentid, userDetails.getUser(), response);
 			return responseDto;
 		}
 	}

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -38,10 +38,15 @@ public class CommentController {
 	public Object updateComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		CommentResponseDto responseDto = commentService.updateComment(postId, commentId, requestDto, userDetails.getUser(), response);
 
+		// 다른 유저가 수정을 시도할 경우 오류 메시지 반환
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_ONLY_ERROR);
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 메시지 반환
 		} else if (response.getStatus() == 404) {
 			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
+
+		// 오류가 나지 않을 경우 해당 댓글 수정
 		} else {
 			return responseDto;
 		}
@@ -52,10 +57,15 @@ public class CommentController {
 	public Object deleteComment(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		commentService.deleteComment(postId, commentId, userDetails.getUser(), response);
 
+		// 다른 유저가 삭제를 시도할 경우 오류 메시지 반환
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_ONLY_ERROR);
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 메시지 반환
 		} else if (response.getStatus() == 404) {
 			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
+
+		// 오류가 나지 않을 경우 해당 댓글 삭제
 		} else {
 			return new ResponseMessageDto("해당 댓글의 삭제를 완료했습니다.", response.getStatus());
 		}
@@ -66,10 +76,15 @@ public class CommentController {
 	public Object commentLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		CommentResponseDto responseDto = commentService.commentLike(postId, commentId, userDetails.getUser(), response);
 
+		// 작성한 유저가 좋아요를 시도할 경우 오류 메시지 반환
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_NOT_ERROR);
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 메시지 반환
 		} else if (response.getStatus() == 404) {
 			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
+
+		// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
 		} else {
 			return responseDto;
 		}

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -11,27 +11,37 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/post")
+@RequestMapping("/api/posts")
 public class CommentController {
 	private final CommentService commentService;
 	private final ResponseMessageUtil responseMessageUtil;
 
+	// 선택한 게시글에 대한 모든 댓글 조회
+	@GetMapping("/{postid}/comments")
+	public List<CommentResponseDto> getCommentsByPostId(@PathVariable Long postid) {
+		return commentService.getCommentsByPostId(postid);
+	}
+
 	// 댓글 작성
-	@PostMapping("/{postid}/comment")
+	@PostMapping("/{postid}/comments")
 	public CommentResponseDto createComment(@PathVariable Long postid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
 		return commentService.createComment(postid, requestDto, userDetails.getUser());
 	}
 
 	// 선택한 댓글 수정
-	@PutMapping("/{postid}/comment/{commentid}")
+	@PutMapping("/{postid}/comments/{commentid}")
 	public CommentResponseDto updateComment(@PathVariable Long postid, @PathVariable Long commentid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
 		CommentResponseDto responseDto = commentService.updateComment(postid, commentid, requestDto, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
 			responseMessageUtil.statusResponse(response, "작성자만 수정할 수 있습니다.");
+			return null;
+		} else if (response.getStatus() == 404) {
+			responseMessageUtil.statusResponse(response, "주소가 잘못되어 해당 댓글을 찾을 수 없습니다.");
 			return null;
 		} else {
 			return responseDto;
@@ -39,22 +49,31 @@ public class CommentController {
 	}
 
 	// 선택한 댓글 삭제
-	@DeleteMapping("/{postid}/comment/{commentid}")
+	@DeleteMapping("/{postid}/comments/{commentid}")
 	public void deleteComment(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
 		commentService.deleteComment(postid, commentid, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
 			responseMessageUtil.statusResponse(response, "작성자만 삭제할 수 있습니다.");
+		} else if (response.getStatus() == 404) {
+			responseMessageUtil.statusResponse(response, "주소가 잘못되어 해당 댓글을 찾을 수 없습니다.");
 		} else {
 			responseMessageUtil.statusResponse(response, "해당 댓글의 삭제를 완료하였습니다.");
 		}
 	}
 
 	// 선택한 댓글 좋아요
-	@PutMapping("/comments/{id}/likes")
-	public CommentResponseDto commentLike(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
-		CommentResponseDto responseDto = commentService.commentLike(id, userDetails.getUser(), response);
-
-		return responseDto;
+	@PutMapping("/{postid}/comments/{commentid}/likes")
+	public CommentResponseDto commentLike(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+		if (response.getStatus() == 400) {
+			responseMessageUtil.statusResponse(response, "본인이 작성한 댓글에는 좋아요를 누를 수 없습니다.");
+			return null;
+		} else if (response.getStatus() == 404) {
+			responseMessageUtil.statusResponse(response, "주소가 잘못되어 해당 댓글을 찾을 수 없습니다.");
+			return null;
+		} else {
+			CommentResponseDto responseDto = commentService.commentLike(postid, commentid, userDetails.getUser(), response);
+			return responseDto;
+		}
 	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -16,27 +16,27 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/posts")
+@RequestMapping("/api/post")
 public class CommentController {
 	private final CommentService commentService;
 	private final GlobalExceptionHandler globalExceptionHandler;
 
 	// 선택한 게시글에 대한 모든 댓글 조회
-	@GetMapping("/{postid}/comments")
-	public List<CommentResponseDto> getCommentsByPostId(@PathVariable Long postid) {
-		return commentService.getCommentsByPostId(postid);
+	@GetMapping("/{postId}/comment")
+	public List<CommentResponseDto> getCommentsByPostId(@PathVariable Long postId) {
+		return commentService.getCommentsByPostId(postId);
 	}
 
 	// 댓글 작성
-	@PostMapping("/{postid}/comments")
-	public CommentResponseDto createComment(@PathVariable Long postid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return commentService.createComment(postid, requestDto, userDetails.getUser());
+	@PostMapping("/{postId}/comment")
+	public CommentResponseDto createComment(@PathVariable Long postId, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		return commentService.createComment(postId, requestDto, userDetails.getUser());
 	}
 
 	// 선택한 댓글 수정
-	@PutMapping("/{postid}/comments/{commentid}")
-	public Object updateComment(@PathVariable Long postid, @PathVariable Long commentid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
-		CommentResponseDto responseDto = commentService.updateComment(postid, commentid, requestDto, userDetails.getUser(), response);
+	@PutMapping("/{postId}/comment/{commentId}")
+	public Object updateComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+		CommentResponseDto responseDto = commentService.updateComment(postId, commentId, requestDto, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_ONLY_ERROR);
@@ -48,9 +48,9 @@ public class CommentController {
 	}
 
 	// 선택한 댓글 삭제
-	@DeleteMapping("/{postid}/comments/{commentid}")
-	public Object deleteComment(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
-		commentService.deleteComment(postid, commentid, userDetails.getUser(), response);
+	@DeleteMapping("/{postId}/comment/{commentId}")
+	public Object deleteComment(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+		commentService.deleteComment(postId, commentId, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_ONLY_ERROR);
@@ -62,9 +62,9 @@ public class CommentController {
 	}
 
 	// 선택한 댓글 좋아요
-	@PutMapping("/{postid}/comments/{commentid}/likes")
-	public Object commentLike(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
-		CommentResponseDto responseDto = commentService.commentLike(postid, commentid, userDetails.getUser(), response);
+	@PutMapping("/{postId}/comment/{commentId}/likes")
+	public Object commentLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+		CommentResponseDto responseDto = commentService.commentLike(postId, commentId, userDetails.getUser(), response);
 
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_NOT_ERROR);

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -1,0 +1,4 @@
+package com.sparta.trillionnewspeedproject.controller;
+
+public class CommentController {
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -1,4 +1,60 @@
 package com.sparta.trillionnewspeedproject.controller;
 
+import com.sparta.trillionnewspeedproject.dto.CommentRequestDto;
+import com.sparta.trillionnewspeedproject.dto.CommentResponseDto;
+import com.sparta.trillionnewspeedproject.util.ResponseMessageUtil;
+import com.sparta.trillionnewspeedproject.security.UserDetailsImpl;
+import com.sparta.trillionnewspeedproject.service.CommentService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/post")
 public class CommentController {
+	private final CommentService commentService;
+	private final ResponseMessageUtil responseMessageUtil;
+
+	// 댓글 작성
+	@PostMapping("/{postid}/comment")
+	public CommentResponseDto createComment(@PathVariable Long postid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		return commentService.createComment(postid, requestDto, userDetails.getUser());
+	}
+
+	// 선택한 댓글 수정
+	@PutMapping("/{postid}/comment/{commentid}")
+	public CommentResponseDto updateComment(@PathVariable Long postid, @PathVariable Long commentid, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+		CommentResponseDto responseDto = commentService.updateComment(postid, commentid, requestDto, userDetails.getUser(), response);
+
+		if (response.getStatus() == 400) {
+			responseMessageUtil.statusResponse(response, "작성자만 수정할 수 있습니다.");
+			return null;
+		} else {
+			return responseDto;
+		}
+	}
+
+	// 선택한 댓글 삭제
+	@DeleteMapping("/{postid}/comment/{commentid}")
+	public void deleteComment(@PathVariable Long postid, @PathVariable Long commentid, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+		commentService.deleteComment(postid, commentid, userDetails.getUser(), response);
+
+		if (response.getStatus() == 400) {
+			responseMessageUtil.statusResponse(response, "작성자만 삭제할 수 있습니다.");
+		} else {
+			responseMessageUtil.statusResponse(response, "해당 댓글의 삭제를 완료하였습니다.");
+		}
+	}
+
+	// 선택한 댓글 좋아요
+	@PutMapping("/comments/{id}/likes")
+	public CommentResponseDto commentLike(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) throws IOException {
+		CommentResponseDto responseDto = commentService.commentLike(id, userDetails.getUser(), response);
+
+		return responseDto;
+	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -16,25 +16,25 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/post")
+@RequestMapping("/api/posts")
 public class CommentController {
 	private final CommentService commentService;
 	private final GlobalExceptionHandler globalExceptionHandler;
 
 	// 선택한 게시글에 대한 모든 댓글 조회
-	@GetMapping("/{postId}/comment")
+	@GetMapping("/{postId}/comments")
 	public List<CommentResponseDto> getCommentsByPostId(@PathVariable Long postId) {
 		return commentService.getCommentsByPostId(postId);
 	}
 
 	// 댓글 작성
-	@PostMapping("/{postId}/comment")
+	@PostMapping("/{postId}/comments")
 	public CommentResponseDto createComment(@PathVariable Long postId, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
 		return commentService.createComment(postId, requestDto, userDetails.getUser());
 	}
 
 	// 선택한 댓글 수정
-	@PutMapping("/{postId}/comment/{commentId}")
+	@PutMapping("/{postId}/comments/{commentId}")
 	public Object updateComment(@PathVariable Long postId, @PathVariable Long commentId, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		CommentResponseDto responseDto = commentService.updateComment(postId, commentId, requestDto, userDetails.getUser(), response);
 
@@ -53,7 +53,7 @@ public class CommentController {
 	}
 
 	// 선택한 댓글 삭제
-	@DeleteMapping("/{postId}/comment/{commentId}")
+	@DeleteMapping("/{postId}/comments/{commentId}")
 	public Object deleteComment(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		commentService.deleteComment(postId, commentId, userDetails.getUser(), response);
 
@@ -72,7 +72,7 @@ public class CommentController {
 	}
 
 	// 선택한 댓글 좋아요
-	@PutMapping("/{postId}/comment/{commentId}/likes")
+	@PutMapping("/{postId}/comments/{commentId}/likes")
 	public Object commentLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
 		CommentResponseDto responseDto = commentService.commentLike(postId, commentId, userDetails.getUser(), response);
 

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 public class CommentRequestDto {
 	@NotBlank
-	private String comment;
+	private String contents;
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
@@ -1,4 +1,10 @@
 package com.sparta.trillionnewspeedproject.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
 public class CommentRequestDto {
+	@NotBlank
+	private String comment;
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
@@ -1,0 +1,4 @@
+package com.sparta.trillionnewspeedproject.dto;
+
+public class CommentRequestDto {
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentRequestDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 public class CommentRequestDto {
 	@NotBlank
-	private String contents;
+	private String commentContents;
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
@@ -10,14 +10,16 @@ public class CommentResponseDto {
 	private Long id;
 	private String username;
 	private LocalDateTime createdAt;
-	private String comment;
+	private LocalDateTime modifiedAt;
+	private String contents;
 	private int likes;
 
 	public CommentResponseDto(Comment comment) {
 		this.id = comment.getId();
 		this.username = comment.getUser().getUsername();
 		this.createdAt = comment.getCreatedAt();
-		this.comment = comment.getComment();
+		this.modifiedAt = comment.getModifiedAt();
+		this.contents = comment.getContents();
 		this.likes = comment.getLikes();
 	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
@@ -1,4 +1,23 @@
 package com.sparta.trillionnewspeedproject.dto;
 
+import com.sparta.trillionnewspeedproject.entity.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class CommentResponseDto {
+	private Long id;
+	private String username;
+	private LocalDateTime createdAt;
+	private String comment;
+	private int likes;
+
+	public CommentResponseDto(Comment comment) {
+		this.id = comment.getId();
+		this.username = comment.getUser().getUsername();
+		this.createdAt = comment.getCreatedAt();
+		this.comment = comment.getComment();
+		this.likes = comment.getLikes();
+	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
@@ -1,0 +1,4 @@
+package com.sparta.trillionnewspeedproject.dto;
+
+public class CommentResponseDto {
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
@@ -7,19 +7,19 @@ import java.time.LocalDateTime;
 
 @Getter
 public class CommentResponseDto {
-	private Long id;
+   	private Long commentId;
 	private String username;
 	private LocalDateTime createdAt;
 	private LocalDateTime modifiedAt;
-	private String contents;
+	private String commentContents;
 	private int likes;
 
 	public CommentResponseDto(Comment comment) {
-		this.id = comment.getId();
+		this.commentId = comment.getCommentId();
 		this.username = comment.getUser().getUsername();
 		this.createdAt = comment.getCreatedAt();
 		this.modifiedAt = comment.getModifiedAt();
-		this.contents = comment.getContents();
+		this.commentContents = comment.getCommentContents();
 		this.likes = comment.getLikes();
 	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/ResponseMessageDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/ResponseMessageDto.java
@@ -1,0 +1,14 @@
+package com.sparta.trillionnewspeedproject.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ResponseMessageDto {
+	private String message;
+	private int status;
+
+	public ResponseMessageDto(String message, int status) {
+		this.message = message;
+		this.status = status;
+	}
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -19,13 +19,13 @@ public class Comment extends Timestamped {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private Long commentId;
 
 	@Column(name = "contents", nullable = false, length = 100)
-	private String contents;
+	private String commentContents;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_userId", nullable = false)
+	@JoinColumn(name = "userId", nullable = false)
 	private User user;
 
 	@Column(name = "likes")
@@ -33,12 +33,12 @@ public class Comment extends Timestamped {
 
 	public Comment(Post post, CommentRequestDto requestDto, User user) {
 		this.post = post;
-		this.contents = requestDto.getContents();
+		this.commentContents = requestDto.getCommentContents();
 		this.user = user;
 	}
 
 	public void update(CommentRequestDto requestDto) {
-		this.contents = requestDto.getContents();
+		this.commentContents = requestDto.getCommentContents();
 	}
 
 	public void updateLikes() {

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -1,0 +1,4 @@
+package com.sparta.trillionnewspeedproject.entity;
+
+public class Comment {
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -1,4 +1,47 @@
 package com.sparta.trillionnewspeedproject.entity;
 
-public class Comment {
+import com.sparta.trillionnewspeedproject.dto.CommentRequestDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "comments")
+@NoArgsConstructor
+public class Comment extends Timestamped {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private Post post;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "comment", nullable = false, length = 100)
+	private String comment;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_username", nullable = false)
+	private User user;
+
+	@Column(name = "likes")
+	private int likes;
+
+	public Comment(Post post, CommentRequestDto requestDto, User user) {
+		this.post = post;
+		this.comment = requestDto.getComment();
+		this.user = user;
+	}
+
+	public void update(CommentRequestDto requestDto) {
+		this.comment = requestDto.getComment();
+	}
+
+	public void updateLikes() {
+		this.likes++;
+	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -14,18 +14,18 @@ import lombok.Setter;
 public class Comment extends Timestamped {
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id", nullable = false)
+	@JoinColumn(name = "post_postId", nullable = false)
 	private Post post;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "comment", nullable = false, length = 100)
-	private String comment;
+	@Column(name = "contents", nullable = false, length = 100)
+	private String contents;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_username", nullable = false)
+	@JoinColumn(name = "user_userId", nullable = false)
 	private User user;
 
 	@Column(name = "likes")
@@ -33,12 +33,12 @@ public class Comment extends Timestamped {
 
 	public Comment(Post post, CommentRequestDto requestDto, User user) {
 		this.post = post;
-		this.comment = requestDto.getComment();
+		this.contents = requestDto.getContents();
 		this.user = user;
 	}
 
 	public void update(CommentRequestDto requestDto) {
-		this.comment = requestDto.getComment();
+		this.contents = requestDto.getContents();
 	}
 
 	public void updateLikes() {

--- a/src/main/java/com/sparta/trillionnewspeedproject/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.sparta.trillionnewspeedproject.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+	USER_ONLY_ERROR(HttpStatus.BAD_REQUEST, "작성자만 삭제/수정할 수 있습니다."),
+	USER_NOT_ERROR(HttpStatus.BAD_REQUEST, "작성자는 좋아요를 누를 수 없습니다."),
+	NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "주소가 잘못되어 해당 페이지를 찾을 수 없습니다.");
+	private final HttpStatus status;
+	private final String message;
+
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+	ErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.sparta.trillionnewspeedproject.exception;
+
+import com.sparta.trillionnewspeedproject.dto.ResponseMessageDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Component // @RestControllerAdvice 사용법을 아직 잘 모르겠음..
+public class GlobalExceptionHandler {
+
+	// 에러 처리
+	@ExceptionHandler
+	public ResponseMessageDto badRequestException(ErrorCode errorCode) {
+		return new ResponseMessageDto(errorCode.getMessage(), errorCode.getStatus().value());
+	}
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentRepository.java
@@ -1,0 +1,4 @@
+package com.sparta.trillionnewspeedproject.repository;
+
+public interface CommentRepository {
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentRepository.java
@@ -1,4 +1,10 @@
 package com.sparta.trillionnewspeedproject.repository;
 
-public interface CommentRepository {
+import com.sparta.trillionnewspeedproject.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+	List<Comment> findAllByPost_idOrderByCreatedAtDesc(Long post_id);
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -39,12 +39,18 @@ public class CommentService {
 	// 선택한 댓글 수정
 	@Transactional
 	public CommentResponseDto updateComment(Long postId, Long commentId, CommentRequestDto requestDto, User user, HttpServletResponse response) {
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
 		if (postId != findComment(commentId).getPost().getId()) {
 			response.setStatus(404);
 			return null;
+
+		// 다른 유저가 수정을 시도할 경우 오류 코드 반환
 		} else if (!checkUser(commentId, user)) {
 			response.setStatus(400);
 			return null;
+
+		// 오류가 나지 않을 경우 해당 댓글 수정
 		} else {
 			findComment(commentId).update(requestDto);
 			CommentResponseDto commentResponseDto = new CommentResponseDto(findComment(commentId));
@@ -54,10 +60,16 @@ public class CommentService {
 
 	// 선택한 댓글 삭제
 	public void deleteComment(Long postId, Long commentId, @AuthenticationPrincipal User user, HttpServletResponse response) {
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
 		if (postId != findComment(commentId).getPost().getId()) {
 			response.setStatus(404);
+
+		// 다른 유저가 삭제를 시도할 경우 오류 코드 반환
 		} else if (!checkUser(commentId, user)) {
 			response.setStatus(400);
+
+		// 오류가 나지 않을 경우 해당 댓글 삭제
 		} else {
 			commentRepository.delete(findComment(commentId));
 		}
@@ -65,12 +77,18 @@ public class CommentService {
 
 	// 선택한 댓글 좋아요 기능 추가
 	public CommentResponseDto commentLike(Long postId, Long commentId, User user, HttpServletResponse response) {
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
 		if (postId != findComment(commentId).getPost().getId()) {
 			response.setStatus(404);
 			return null;
+
+		// 작성자가 좋아요를 시도할 경우 오류 코드 반환
 		} else if (checkUser(commentId, user)) {
 			response.setStatus(400);
 			return null;
+
+		// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
 		} else {
 			Comment comment = findComment(commentId);
 			comment.updateLikes();

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -1,0 +1,4 @@
+package com.sparta.trillionnewspeedproject.service;
+
+public class CommentService {
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -1,4 +1,91 @@
 package com.sparta.trillionnewspeedproject.service;
 
+import com.sparta.trillionnewspeedproject.dto.CommentRequestDto;
+import com.sparta.trillionnewspeedproject.dto.CommentResponseDto;
+import com.sparta.trillionnewspeedproject.entity.Comment;
+import com.sparta.trillionnewspeedproject.entity.Post;
+import com.sparta.trillionnewspeedproject.entity.User;
+import com.sparta.trillionnewspeedproject.repository.CommentRepository;
+import com.sparta.trillionnewspeedproject.repository.PostRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class CommentService {
+
+	private final CommentRepository commentRepository;
+	private final PostRepository postRepository;
+
+	// 댓글 작성
+	public CommentResponseDto createComment(Long postid, CommentRequestDto requestDto, User user) {
+		Post post = postRepository.getById(postid);
+		Comment comment = new Comment(post, requestDto, user);
+		Comment saveComment = commentRepository.save(comment);
+		CommentResponseDto commentResponseDto = new CommentResponseDto(saveComment);
+		return commentResponseDto;
+	}
+
+	// 선택한 댓글 수정
+	@Transactional
+	public CommentResponseDto updateComment(Long postid, Long commentid, CommentRequestDto requestDto, User user, HttpServletResponse response) {
+		if (!checkUser(commentid, user)) {
+			response.setStatus(400);
+			return null;
+		} else {
+			findComment(commentid).update(requestDto);
+			CommentResponseDto commentResponseDto = new CommentResponseDto(findComment(id));
+			return commentResponseDto;
+		}
+	}
+
+	// 선택한 댓글 삭제
+	public void deleteComment(Long postid, Long commentid, @AuthenticationPrincipal User user, HttpServletResponse response) {
+		if (!checkUser(commentid, user)) {
+			response.setStatus(400);
+		} else {
+			commentRepository.delete(findComment(commentid));
+		}
+	}
+
+	// 선택한 게시글에 대한 댓글 전체 조회
+	public List<CommentResponseDto> getComments(Long postid) {
+		return commentRepository.findAllByPost_idOrderByCreatedAtDesc(postid).stream().map(CommentResponseDto::new).toList();
+	}
+
+	// 선택한 댓글 좋아요 기능 추가
+	public CommentResponseDto commentLike(Long id, User user, HttpServletResponse response) {
+		if (checkUser(id, user)) {
+			response.setStatus(400);
+			return null;
+		} else {
+			Comment comment = findComment(id);
+			comment.updateLikes();
+			Comment savedComment = commentRepository.save(comment);
+			CommentResponseDto commentResponseDto = new CommentResponseDto(savedComment);
+			return commentResponseDto;
+		}
+	}
+
+	// id에 따른 댓글 찾기
+	private Comment findComment(Long id) {
+		return commentRepository.findById(id).orElseThrow(() ->
+				new IllegalArgumentException("선택한 게시글은 존재하지 않습니다.")
+		);
+	}
+
+	// 선택한 댓글의 사용자가 맞는지 혹은 관리자인지 확인하기
+	private boolean checkUser(Long selectId, User user) {
+		Comment comment = findComment(selectId);
+		if (comment.getUser().getUsername().equals(user.getUsername()) || user.getRole().getAuthority().equals("ROLE_ADMIN")) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -22,6 +22,11 @@ public class CommentService {
 	private final CommentRepository commentRepository;
 	private final PostRepository postRepository;
 
+	// 선택한 게시글에 대한 댓글 전체 조회
+	public List<CommentResponseDto> getCommentsByPostId(Long postid) {
+		return commentRepository.findAllByPost_idOrderByCreatedAtDesc(postid).stream().map(CommentResponseDto::new).toList();
+	}
+
 	// 댓글 작성
 	public CommentResponseDto createComment(Long postid, CommentRequestDto requestDto, User user) {
 		Post post = postRepository.getById(postid);
@@ -34,37 +39,40 @@ public class CommentService {
 	// 선택한 댓글 수정
 	@Transactional
 	public CommentResponseDto updateComment(Long postid, Long commentid, CommentRequestDto requestDto, User user, HttpServletResponse response) {
-		if (!checkUser(commentid, user)) {
+		if (postid != findComment(commentid).getPost().getId()) {
+			response.setStatus(404);
+			return null;
+		} else if (!checkUser(commentid, user)) {
 			response.setStatus(400);
 			return null;
 		} else {
 			findComment(commentid).update(requestDto);
-			CommentResponseDto commentResponseDto = new CommentResponseDto(findComment(id));
+			CommentResponseDto commentResponseDto = new CommentResponseDto(findComment(commentid));
 			return commentResponseDto;
 		}
 	}
 
 	// 선택한 댓글 삭제
 	public void deleteComment(Long postid, Long commentid, @AuthenticationPrincipal User user, HttpServletResponse response) {
-		if (!checkUser(commentid, user)) {
+		if (postid != findComment(commentid).getPost().getId()) {
+			response.setStatus(404);
+		} else if (!checkUser(commentid, user)) {
 			response.setStatus(400);
 		} else {
 			commentRepository.delete(findComment(commentid));
 		}
 	}
 
-	// 선택한 게시글에 대한 댓글 전체 조회
-	public List<CommentResponseDto> getComments(Long postid) {
-		return commentRepository.findAllByPost_idOrderByCreatedAtDesc(postid).stream().map(CommentResponseDto::new).toList();
-	}
-
 	// 선택한 댓글 좋아요 기능 추가
-	public CommentResponseDto commentLike(Long id, User user, HttpServletResponse response) {
-		if (checkUser(id, user)) {
+	public CommentResponseDto commentLike(Long postid, Long commentid, User user, HttpServletResponse response) {
+		if (postid != findComment(commentid).getPost().getId()) {
+			response.setStatus(404);
+			return null;
+		} else if (checkUser(commentid, user)) {
 			response.setStatus(400);
 			return null;
 		} else {
-			Comment comment = findComment(id);
+			Comment comment = findComment(commentid);
 			comment.updateLikes();
 			Comment savedComment = commentRepository.save(comment);
 			CommentResponseDto commentResponseDto = new CommentResponseDto(savedComment);
@@ -73,8 +81,15 @@ public class CommentService {
 	}
 
 	// id에 따른 댓글 찾기
-	private Comment findComment(Long id) {
-		return commentRepository.findById(id).orElseThrow(() ->
+	private Comment findComment(Long commentid) {
+		return commentRepository.findById(commentid).orElseThrow(() ->
+				new IllegalArgumentException("선택한 게시글은 존재하지 않습니다.")
+		);
+	}
+
+	// id에 따른 게시글 찾기
+	private Post findPost(Long id) {
+		return postRepository.findById(id).orElseThrow(() ->
 				new IllegalArgumentException("선택한 게시글은 존재하지 않습니다.")
 		);
 	}


### PR DESCRIPTION
Commit 1. comment 기본 CRUD 기능 및 좋아요 기능
-기본적인 내용만 담아두었으므로 세부적인 내용은 다른 분들 코드 보면서 수정 및 조정해야 함
-좋아요 기능 취소가 가능해야 하므로 entity 새로 구성해야 할 듯 함 -> 이후 수정 및 개선 예정

Commit 2. 선택한 게시글에 대한 모든 댓글 조회 API 추가 및 postid를 Pathvariable로 받는 부분에 대한 코드 수정
-선택한 게시글 id를 Pathvariable로 받으면 해당 게시글에 대한 댓글을 모두 조회할 수 있도록 추가
(백엔드만 구현시 필요하지 않지 않을 것 같지만 프론트엔드를 구현시에 필요할 듯 하여 추가함)
-postid를 pathvariable 방식으로 받도록 코드 수정
-Pathvariable로 받은 posIid와 comment의 DB에 존재하는 postId가 일치하지 않다면 예외처리를 하도록 코드 수정
-예외처리 중 수정기능, 좋아요기능에서 Response에 message가 반환이 되지 않아 이후 수정 예정

Commit 3. 예외 처리 관련 코드 수정
-수정 기능, 좋아요 기능 예외처리 시 ResponseMessage가 반환이 안되는 문제 해결
-포스트 아이디나 댓글 아이디가 없는 번호일 때 예외처리 -> 아직 미해결. 추후 구현 예정

Commit 4. api 명세서에 맞춰 수정, User 기능 관련 작성된 코드에 맞춰 수정
-약속된 api 명세서와 다르게 잘못 작성되어 해당 내용 수정
-User와 연관된 코드를 User 브랜치에 작성된 코드에 맞춰 수정

Commit 5. ERD에 맞춘 코드 수정 및 API 명세서 수정에 따른 코드 재수정, PR에서 의논된 내용에 맞춰 코드 수정
-약속된 ERD와 다른 내용으로 작성된 코드가 있어 수정
-API 명세의 수정이 생겨 해당 내용에 맞게 코드 재수정
-PR에서 의논된 내용에 맞춰 코드 수정