### PR TITLE
댓글 좋아요 추가 및 취소 기능 구현

### DIFF
--- a/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/controller/CommentController.java
@@ -71,20 +71,47 @@ public class CommentController {
 		}
 	}
 
-	// 선택한 댓글 좋아요
-	@PutMapping("/{postId}/comments/{commentId}/likes")
-	public Object commentLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
-		CommentResponseDto responseDto = commentService.commentLike(postId, commentId, userDetails.getUser(), response);
+	// 선택한 댓글 좋아요 추가
+	@PostMapping("/{postId}/comments/{commentId}/like")
+	public Object commentInsertLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+		CommentResponseDto responseDto = commentService.commentInsertLike(postId, commentId, userDetails.getUser(), response);
 
 		// 작성한 유저가 좋아요를 시도할 경우 오류 메시지 반환
 		if (response.getStatus() == 400) {
 			return globalExceptionHandler.badRequestException(ErrorCode.USER_NOT_ERROR);
 
-		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 메시지 반환
+			// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 메시지 반환
 		} else if (response.getStatus() == 404) {
 			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
 
-		// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
+			// 사용자가 이미 좋아요를 누른 경우 오류 메시지 반환
+		} else if (response.getStatus() == 409) {
+			return globalExceptionHandler.badRequestException(ErrorCode.LIKE_PRESENT);
+
+			// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
+		} else {
+			return responseDto;
+		}
+	}
+
+	// 선택한 댓글 좋아요 취소
+	@DeleteMapping("/{postId}/comments/{commentId}/like")
+	public Object commentDeleteLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+		CommentResponseDto responseDto = commentService.commentDeleteLike(postId, commentId, userDetails.getUser(), response);
+
+		// 작성한 유저가 좋아요를 시도할 경우 오류 메시지 반환
+		if (response.getStatus() == 400) {
+			return globalExceptionHandler.badRequestException(ErrorCode.USER_NOT_ERROR);
+
+			// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 메시지 반환
+		} else if (response.getStatus() == 404) {
+			return globalExceptionHandler.badRequestException(ErrorCode.NOT_FOUND_ERROR);
+
+			// 사용자가 좋아요를 누른 적이 없는 경우 오류 메시지 반환
+		} else if (response.getStatus() == 409) {
+			return globalExceptionHandler.badRequestException(ErrorCode.LIKE_EMPTY);
+
+			// 오류가 나지 않을 경우 해당 댓글 좋아요 취소
 		} else {
 			return responseDto;
 		}

--- a/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/dto/CommentResponseDto.java
@@ -12,7 +12,7 @@ public class CommentResponseDto {
 	private LocalDateTime createdAt;
 	private LocalDateTime modifiedAt;
 	private String commentContents;
-	private int likes;
+	private long likeCnt;
 
 	public CommentResponseDto(Comment comment) {
 		this.commentId = comment.getCommentId();
@@ -20,6 +20,6 @@ public class CommentResponseDto {
 		this.createdAt = comment.getCreatedAt();
 		this.modifiedAt = comment.getModifiedAt();
 		this.commentContents = comment.getCommentContents();
-		this.likes = comment.getLikes();
+		this.likeCnt = comment.getLikeCnt();
 	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -28,8 +28,8 @@ public class Comment extends Timestamped {
 	@JoinColumn(name = "userId", nullable = false)
 	private User user;
 
-	@Column(name = "likes")
-	private int likes;
+	@Column(name = "likeCnt")
+	private long likeCnt;
 
 	public Comment(Post post, CommentRequestDto requestDto, User user) {
 		this.post = post;
@@ -41,7 +41,7 @@ public class Comment extends Timestamped {
 		this.commentContents = requestDto.getCommentContents();
 	}
 
-	public void updateLikes() {
-		this.likes++;
+	public void updateLikeCnt(long likeCnt) {
+		this.likeCnt = likeCnt;
 	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -31,6 +33,10 @@ public class Comment extends Timestamped {
 	@Column(name = "likeCnt")
 	private long likeCnt;
 
+	@OneToMany(mappedBy = "comment", orphanRemoval = true)
+	private List<CommentLike> commentLikeList;
+
+
 	public Comment(Post post, CommentRequestDto requestDto, User user) {
 		this.post = post;
 		this.commentContents = requestDto.getCommentContents();
@@ -41,7 +47,11 @@ public class Comment extends Timestamped {
 		this.commentContents = requestDto.getCommentContents();
 	}
 
-	public void updateLikeCnt(long likeCnt) {
-		this.likeCnt = likeCnt;
+	public void insertLikeCnt() {
+		this.likeCnt++;
+	}
+
+	public void deleteLikeCnt() {
+		this.likeCnt--;
 	}
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/Comment.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class Comment extends Timestamped {
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_postId", nullable = false)
+	@JoinColumn(name = "postId", nullable = false)
 	private Post post;
 
 	@Id

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/CommentLike.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/CommentLike.java
@@ -1,0 +1,30 @@
+package com.sparta.trillionnewspeedproject.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "commentLike")
+public class CommentLike {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column
+	private Long commentLikeId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "username")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "commentId")
+	private Comment comment;
+
+	public CommentLike(User user, Comment comment) {
+		this.user = user;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/entity/CommentLike.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/entity/CommentLike.java
@@ -16,7 +16,7 @@ public class CommentLike {
 	private Long commentLikeId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "username")
+	@JoinColumn(name = "userId")
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/sparta/trillionnewspeedproject/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/exception/ErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 	USER_ONLY_ERROR(HttpStatus.BAD_REQUEST, "작성자만 삭제/수정할 수 있습니다."),
 	USER_NOT_ERROR(HttpStatus.BAD_REQUEST, "작성자는 좋아요를 누를 수 없습니다."),
-	NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "주소가 잘못되어 해당 페이지를 찾을 수 없습니다.");
+	NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "주소가 잘못되어 해당 페이지를 찾을 수 없습니다."),
+	LIKE_PRESENT(HttpStatus.CONFLICT, "좋아요를 이미 누르셨습니다."),
+	LIKE_EMPTY(HttpStatus.CONFLICT, "좋아요를 누르시지 않았습니다.");
 	private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentLikeRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.trillionnewspeedproject.repository;
+
+import com.sparta.trillionnewspeedproject.entity.Comment;
+import com.sparta.trillionnewspeedproject.entity.CommentLike;
+import com.sparta.trillionnewspeedproject.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+	Optional<CommentLike> findByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/repository/CommentRepository.java
@@ -1,10 +1,13 @@
 package com.sparta.trillionnewspeedproject.repository;
 
 import com.sparta.trillionnewspeedproject.entity.Comment;
+import com.sparta.trillionnewspeedproject.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-	List<Comment> findAllByPost_idOrderByCreatedAtDesc(Long post_id);
+	List<Comment> findAllByPostOrderByCreatedAtDesc(Post post);
 }

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -88,20 +88,20 @@ public class CommentService {
 			response.setStatus(404);
 			return null;
 
-			// 작성자가 좋아요를 시도할 경우 오류 코드 반환
+		// 작성자가 좋아요를 시도할 경우 오류 코드 반환
 		} else if (checkUser(commentId, user)) {
 			response.setStatus(400);
 			return null;
 
-			// 좋아요를 이미 누른 경우 오류 코드 반환
+		// 좋아요를 이미 누른 경우 오류 코드 반환
 		} else if (findCommentLike(user, comment) != null) {
 			response.setStatus(409);
 			return null;
 
-			// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
+		// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
 		} else {
 			commentLikeRepository.save(new CommentLike(user, comment));
-			comment.updateLikeCnt(commentLikeRepository.count());
+			comment.insertLikeCnt();
 			CommentResponseDto commentResponseDto = new CommentResponseDto(commentRepository.save(comment));
 			return commentResponseDto;
 		}
@@ -115,20 +115,20 @@ public class CommentService {
 			response.setStatus(404);
 			return null;
 
-			// 작성자가 좋아요를 시도할 경우 오류 코드 반환
+		// 작성자가 좋아요를 시도할 경우 오류 코드 반환
 		} else if (checkUser(commentId, user)) {
 			response.setStatus(400);
 			return null;
 
-			// 좋아요를 누른 적이 없는 경우 오류 코드 반환
+		// 좋아요를 누른 적이 없는 경우 오류 코드 반환
 		} else if (findCommentLike(user, comment) == null) {
 			response.setStatus(409);
 			return null;
 
-			// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
+		// 오류가 나지 않을 경우 해당 댓글 좋아요 취소
 		} else {
 			commentLikeRepository.delete(findCommentLike(user, comment));
-			comment.updateLikeCnt(commentLikeRepository.count());
+			comment.deleteLikeCnt();
 			CommentResponseDto commentResponseDto = new CommentResponseDto(commentRepository.save(comment));
 			return commentResponseDto;
 		}

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -3,8 +3,10 @@ package com.sparta.trillionnewspeedproject.service;
 import com.sparta.trillionnewspeedproject.dto.CommentRequestDto;
 import com.sparta.trillionnewspeedproject.dto.CommentResponseDto;
 import com.sparta.trillionnewspeedproject.entity.Comment;
+import com.sparta.trillionnewspeedproject.entity.CommentLike;
 import com.sparta.trillionnewspeedproject.entity.Post;
 import com.sparta.trillionnewspeedproject.entity.User;
+import com.sparta.trillionnewspeedproject.repository.CommentLikeRepository;
 import com.sparta.trillionnewspeedproject.repository.CommentRepository;
 import com.sparta.trillionnewspeedproject.repository.PostRepository;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +23,7 @@ public class CommentService {
 
 	private final CommentRepository commentRepository;
 	private final PostRepository postRepository;
+	private final CommentLikeRepository commentLikeRepository;
 
 	// 선택한 게시글에 대한 댓글 전체 조회
 	public List<CommentResponseDto> getCommentsByPostId(Long postId) {
@@ -75,25 +78,58 @@ public class CommentService {
 		}
 	}
 
+	@Transactional
 	// 선택한 댓글 좋아요 기능 추가
-	public CommentResponseDto commentLike(Long postId, Long commentId, User user, HttpServletResponse response) {
+	public CommentResponseDto commentInsertLike(Long postId, Long commentId, User user, HttpServletResponse response) {
+		Comment comment = findComment(commentId);
 
 		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
-		if (postId != findComment(commentId).getPost().getId()) {
+		if (postId != comment.getPost().getId()) {
 			response.setStatus(404);
 			return null;
 
-		// 작성자가 좋아요를 시도할 경우 오류 코드 반환
+			// 작성자가 좋아요를 시도할 경우 오류 코드 반환
 		} else if (checkUser(commentId, user)) {
 			response.setStatus(400);
 			return null;
 
-		// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
+			// 좋아요를 이미 누른 경우 오류 코드 반환
+		} else if (findCommentLike(user, comment) != null) {
+			response.setStatus(409);
+			return null;
+
+			// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
 		} else {
-			Comment comment = findComment(commentId);
-			comment.updateLikes();
-			Comment savedComment = commentRepository.save(comment);
-			CommentResponseDto commentResponseDto = new CommentResponseDto(savedComment);
+			commentLikeRepository.save(new CommentLike(user, comment));
+			comment.updateLikeCnt(commentLikeRepository.count());
+			CommentResponseDto commentResponseDto = new CommentResponseDto(commentRepository.save(comment));
+			return commentResponseDto;
+		}
+	}
+
+	public CommentResponseDto commentDeleteLike(Long postId, Long commentId, User user, HttpServletResponse response) {
+		Comment comment = findComment(commentId);
+
+		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
+		if (postId != comment.getPost().getId()) {
+			response.setStatus(404);
+			return null;
+
+			// 작성자가 좋아요를 시도할 경우 오류 코드 반환
+		} else if (checkUser(commentId, user)) {
+			response.setStatus(400);
+			return null;
+
+			// 좋아요를 누른 적이 없는 경우 오류 코드 반환
+		} else if (findCommentLike(user, comment) == null) {
+			response.setStatus(409);
+			return null;
+
+			// 오류가 나지 않을 경우 해당 댓글 좋아요 추가
+		} else {
+			commentLikeRepository.delete(findCommentLike(user, comment));
+			comment.updateLikeCnt(commentLikeRepository.count());
+			CommentResponseDto commentResponseDto = new CommentResponseDto(commentRepository.save(comment));
 			return commentResponseDto;
 		}
 	}
@@ -103,6 +139,11 @@ public class CommentService {
 		return commentRepository.findById(commentId).orElseThrow(() ->
 				new IllegalArgumentException("선택한 댓글은 존재하지 않습니다.")
 		);
+	}
+
+	// 사용자와 댓글에 따른 좋아요 찾기
+	private CommentLike findCommentLike(User user, Comment comment) {
+		return commentLikeRepository.findByUserAndComment(user,comment).orElse(null);
 	}
 
 	// id에 따른 게시글 찾기

--- a/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
+++ b/src/main/java/com/sparta/trillionnewspeedproject/service/CommentService.java
@@ -27,7 +27,7 @@ public class CommentService {
 
 	// 선택한 게시글에 대한 댓글 전체 조회
 	public List<CommentResponseDto> getCommentsByPostId(Long postId) {
-		return commentRepository.findAllByPost_idOrderByCreatedAtDesc(postId).stream().map(CommentResponseDto::new).toList();
+		return commentRepository.findAllByPostOrderByCreatedAtDesc(findPost(postId)).stream().map(CommentResponseDto::new).toList();
 	}
 
 	// 댓글 작성
@@ -44,7 +44,7 @@ public class CommentService {
 	public CommentResponseDto updateComment(Long postId, Long commentId, CommentRequestDto requestDto, User user, HttpServletResponse response) {
 
 		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
-		if (postId != findComment(commentId).getPost().getId()) {
+		if (postId != findComment(commentId).getPost().getPost_id()) {
 			response.setStatus(404);
 			return null;
 
@@ -65,7 +65,7 @@ public class CommentService {
 	public void deleteComment(Long postId, Long commentId, @AuthenticationPrincipal User user, HttpServletResponse response) {
 
 		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
-		if (postId != findComment(commentId).getPost().getId()) {
+		if (postId != findComment(commentId).getPost().getPost_id()) {
 			response.setStatus(404);
 
 		// 다른 유저가 삭제를 시도할 경우 오류 코드 반환
@@ -84,7 +84,7 @@ public class CommentService {
 		Comment comment = findComment(commentId);
 
 		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
-		if (postId != comment.getPost().getId()) {
+		if (postId != comment.getPost().getPost_id()) {
 			response.setStatus(404);
 			return null;
 
@@ -111,7 +111,7 @@ public class CommentService {
 		Comment comment = findComment(commentId);
 
 		// postId 받은 것과 comment DB에 저장된 postId가 다를 경우 오류 코드 반환
-		if (postId != comment.getPost().getId()) {
+		if (postId != comment.getPost().getPost_id()) {
 			response.setStatus(404);
 			return null;
 


### PR DESCRIPTION
- 댓글을 작성한 유저가 좋아요/취소를 시도할 경우 오류 메시지 반환
- postId 받은 것과 commentDB에 저장된 postId가 다른 경우 오류 메시지 반환
- 좋아요 추가 시 사용자가 이미 좋아요를 누른 경우, 좋아요 취소 시 사용자가 좋아요를 누르지 않은 경우 오류 메시지 반환
</br>
- 위의 오류에 모두 해당하지 않을 시 좋아요 추가 및 취소 기능 동작
</br></br>
- 댓글 삭제 시 댓글 좋아요가 함께 삭제되도록 함
</br>
- 게시글 코드에 맞춰 코드 수정
</br>
- 선택한 게시글 모든 댓글 조회 시 오류가 생겨 해당 오류 수정
</br></br>
* API 명세서 및 ERD 수정도 완료했습니다!